### PR TITLE
Add support for the Unikraft backend targets

### DIFF
--- a/unikraft/dune
+++ b/unikraft/dune
@@ -1,0 +1,7 @@
+(library
+ (name mirage_mtime_unikraft)
+ (public_name mirage-mtime.unikraft)
+ (implements mirage-mtime)
+ (foreign_stubs
+  (language c)
+  (names stubs)))

--- a/unikraft/mirage_mtime.ml
+++ b/unikraft/mirage_mtime.ml
@@ -1,0 +1,6 @@
+(* C stub implemented in mirage-unikraft *)
+external elapsed_ns : unit -> int64 = "caml_get_monotonic_time"
+external uk_time_tick_ns : unit -> int64 = "uk_time_tick_ns"
+
+let elapsed_ns () = elapsed_ns ()
+let period_ns () = Some (uk_time_tick_ns ())

--- a/unikraft/stubs.c
+++ b/unikraft/stubs.c
@@ -1,0 +1,15 @@
+#ifdef __Unikraft__
+
+#include <caml/alloc.h>
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <uk/plat/time.h>
+
+value uk_time_tick_ns(void)
+{
+  CAMLparam0();
+
+  CAMLreturn(caml_copy_int64(UKPLAT_TIME_TICK_NSEC));
+}
+
+#endif


### PR DESCRIPTION
This PR is part of a set of related PRs to add support for Unikraft backends in the following projects:

- [mirage],
- [mirage-mtime](https://github.com/mirage/mirage-mtime),
- [mirage-ptime](https://github.com/mirage/mirage-ptime),
- [mirage-sleep](https://github.com/mirage/mirage-sleep).

[mirage]: https://github.com/mirage/mirage

Those PRs are joint work with @fabbing and @Firobe.
They are best reviewed together, in particular to be able to test them. See the [related PR] on the [mirage] repository for instructions on how to test them all at once.

[related PR]: https://github.com/mirage/mirage/pull/1607